### PR TITLE
Fix the back button when redirecting to the disclaimer

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -58,7 +58,7 @@ define([
                 var homeView = new HomeView();
                 this.showView(homeView);
             } else {
-                Backbone.history.navigate("disclaimer", {trigger: true});
+                Backbone.history.navigate("disclaimer", {trigger: true, replace: true});
             }
         }
         /**


### PR DESCRIPTION
Don't add an entry in the browser history for the disclaimer path. Otherwise you break the back button by continually redirecting to the to the disclaimer view from the root, and never getting back to the previous page (like phila.gov).
